### PR TITLE
feat(offset_encoding): explicit args for jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ require("ccls").setup {
         -- check :help vim.lsp.start for config options
         server = {
             name = "ccls", --String name
-            cmd = "/usr/bin/ccls", -- point to your binary, has to be string
-            args = {--[[Any args table]]
-            },
-            root_dir = vim.fs.dirname(vim.fs.find({ "compile_commands.json", ".git" }, { upward = true })[1]), -- or some other function
+            cmd = {"/usr/bin/ccls"}, -- point to your binary, has to be a table
+            args = {--[[Any args table]] },
+            offset_encoding = "utf-32", -- When cause problems if not declared
+            root_dir = vim.fs.dirname(vim.fs.find({ "compile_commands.json", ".git" }, { upward = true })[1]), -- or some other function that returns a string
         },
     },
 }

--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -58,8 +58,16 @@ function ccls.setup(config)
                 name = { config.lsp.server.name, "string", false },
                 cmd = { config.lsp.server.cmd, "table", false },
                 args = { config.lsp.server.args, "table", true },
-                root_dir = { config.lsp.server.root_dir, "function", false },
+                offset_encoding = { config.lsp.server.offset_encoding, "string", true },
+                root_dir = { config.lsp.server.root_dir, "string", false },
             }
+            if not utils.tbl_haskey(config.lsp.server, false, "offset_encoding") then
+                vim.notify(
+                    "No offset_encoding encoding specified. If using multiple clients this can potentially cause problems",
+                    vim.log.levels.WARN,
+                    { title = "ccls.nvim" }
+                )
+            end
             vim.api.nvim_create_autocmd("FileType", {
                 pattern = config.filetypes or { "c", "cpp", "objc", "objcpp" },
                 group = vim.api.nvim_create_augroup("ccls_config", { clear = true }),

--- a/lua/ccls/protocol.lua
+++ b/lua/ccls/protocol.lua
@@ -14,6 +14,7 @@ function protocol.nodeRequest(bufnr, method, params, handler)
     end
 
     if client then
+        protocol.offset_encoding = client.offset_encoding or "utf-32"
         client.request(method, params, lspHandler)
     else
         vim.notify("Ccls is not attached to this buffer", vim.log.levels.WARN, { title = "ccls.nvim" })

--- a/lua/ccls/provider.lua
+++ b/lua/ccls/provider.lua
@@ -34,7 +34,7 @@ local function jump(location)
     if vim.g.ccls_close_on_jump then
         vim.api.nvim_buf_delete(nodeTree_bufno, { force = true })
     end
-    vim.lsp.util.jump_to_location(location, nil, true)
+    vim.lsp.util.jump_to_location(location, require("ccls.protocol").offset_encoding or "utf-32", true)
 end
 
 --- Get the collapsibleState for a node. The root is returned expanded on

--- a/lua/ccls/tree/node.lua
+++ b/lua/ccls/tree/node.lua
@@ -25,6 +25,9 @@ local function set_collapsed(node, collapsed)
     node.collapsed = collapsed == nil and not node.collapsed or collapsed
 end
 
+--- Return the string representation of the node. The {level} argument represents
+--- the depth level of the node in the tree and it is passed for convenience, to
+--- simplify the implementation and to avoid re-computing the depth.
 local function node_render(node, level)
     local indent = string.rep(" ", 2 * level)
     local mark = "• "

--- a/lua/ccls/tree/utils.lua
+++ b/lua/ccls/tree/utils.lua
@@ -5,7 +5,7 @@ function utils.node_get_tree_item_cb(node, object, status, treeItem)
     if status == "success" then
         local newnode = require "ccls.tree.node"(node.tree, object, treeItem, node)
         table.insert(node.children, newnode)
-        require("ccls.tree.tree").render(newnode.tree)
+        newnode.tree:render()
     end
 end
 


### PR DESCRIPTION
If offset_encoding is not explicit, can cause errors when using multiple clients. 
Document example of passing it through `vim.lsp.start`

Fix minor typos and validations for `vim.lsp.start`