### PR TITLE
fix(win_config): use pairs instead of ipairs for merging config tables

### DIFF
--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -36,12 +36,12 @@ function ccls.setup(config)
 
     if utils.assert_table(config.win_config) then
         if utils.assert_table(config.win_config.sidebar) then
-            for k, v in ipairs(config.win_config.sidebar) do
+            for k, v in pairs(config.win_config.sidebar) do
                 ccls.win_config.sidebar[k] = v
             end
         end
         if utils.assert_table(config.win_config.float) then
-            for k, v in ipairs(config.win_config.sidebar) do
+            for k, v in pairs(config.win_config.float) do
                 ccls.win_config.float[k] = v
             end
         end


### PR DESCRIPTION
Changed the iterator from ipairs to pairs when merging config tables to ensure all key-value pairs are correctly merged into ccls.win_config.