### PR TITLE
fix(provider): fix treesitter not attaching on jump in Neovim 0.12

### DIFF
--- a/lua/ccls/provider.lua
+++ b/lua/ccls/provider.lua
@@ -34,7 +34,23 @@ local function jump(location)
     if vim.g.ccls_close_on_jump then
         vim.api.nvim_buf_delete(nodeTree_bufno, { force = true })
     end
-    vim.lsp.util.jump_to_location(location, require("ccls.protocol").offset_encoding or "utf-32", true)
+    local encoding = require("ccls.protocol").offset_encoding or "utf-32"
+    -- jump_to_location is deprecated since Neovim 0.12; use show_document instead
+    if vim.lsp.util.show_document then
+        vim.lsp.util.show_document(location, encoding, { reuse_win = true, focus = true })
+    else
+        vim.lsp.util.jump_to_location(location, encoding, true)
+    end
+    -- show_document uses nvim_win_set_buf internally, which may bypass BufRead/FileType
+    -- autocmds when the buffer was pre-loaded (e.g. via bufload during hover preview).
+    -- Ensure treesitter attaches if it hasn't already.
+    vim.schedule(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        local ft = vim.bo[bufnr].filetype
+        if ft ~= "" and not vim.treesitter.highlighter.active[bufnr] then
+            pcall(vim.treesitter.start, bufnr)
+        end
+    end)
 end
 
 --- Get the collapsibleState for a node. The root is returned expanded on

--- a/lua/ccls/provider.lua
+++ b/lua/ccls/provider.lua
@@ -41,13 +41,23 @@ local function jump(location)
     else
         vim.lsp.util.jump_to_location(location, encoding, true)
     end
-    -- show_document uses nvim_win_set_buf internally, which may bypass BufRead/FileType
-    -- autocmds when the buffer was pre-loaded (e.g. via bufload during hover preview).
-    -- Ensure treesitter attaches if it hasn't already.
+    -- show_document/jump_to_location use bufload + nvim_win_set_buf internally,
+    -- which do not fire BufRead/FileType autocmds. Without FileType, treesitter
+    -- never attaches. Detect filetype explicitly when missing (setting it fires
+    -- the FileType autocmd, which triggers treesitter), and start treesitter
+    -- manually if it still hasn't attached.
     vim.schedule(function()
         local bufnr = vim.api.nvim_get_current_buf()
         local ft = vim.bo[bufnr].filetype
-        if ft ~= "" and not vim.treesitter.highlighter.active[bufnr] then
+        if ft == "" then
+            local name = vim.api.nvim_buf_get_name(bufnr)
+            if name ~= "" then
+                local detected = vim.filetype.match({ buf = bufnr, filename = name })
+                if detected then
+                    vim.bo[bufnr].filetype = detected
+                end
+            end
+        elseif not vim.treesitter.highlighter.active[bufnr] then
             pcall(vim.treesitter.start, bufnr)
         end
     end)


### PR DESCRIPTION
## Problem

When jumping to a location via ccls tree view (base/derived classes, callers/callees, etc.), treesitter highlighting sometimes fails to activate on the opened file.

**Root cause**: Two related issues:

1. `vim.lsp.util.jump_to_location` is deprecated since Neovim 0.12. Internally it calls `show_document`, which uses `nvim_win_set_buf` to switch the window to the target buffer — rather than `:edit filename`. This means `BufRead`/`FileType` autocmds are not reliably fired.

2. When a buffer is pre-loaded via `vim.fn.bufload` (which happens during hover preview via `preview_location`), subsequent navigation to that buffer only fires `BufEnter`/`BufWinEnter`, not `BufRead`/`FileType`. Since treesitter attaches on `FileType`, it never starts for that buffer.

## Fix

- Replace deprecated `vim.lsp.util.jump_to_location` with `vim.lsp.util.show_document` (with a compatibility fallback for Neovim < 0.12).
- After the jump, use `vim.schedule` to check if treesitter is active on the current buffer and start it if not. `pcall` is used to gracefully handle filetypes with no treesitter parser.

## Test plan

- [ ] Open a C/C++ file with ccls attached
- [ ] Use a ccls hierarchy view (e.g. `:CclsCallHierarchy`, `:CclsBaseHierarchy`)
- [ ] Press Enter on a node to jump to its location
- [ ] Verify treesitter highlighting is active in the opened file (`:TSBufInfo` should show an active highlighter)
- [ ] Repeat after hovering over a symbol first (`K`) to trigger `preview_location` pre-loading