### PR TITLE
fix: use show_document for Neovim 0.12 compatibility

### DIFF
--- a/lua/ccls/provider.lua
+++ b/lua/ccls/provider.lua
@@ -34,7 +34,13 @@ local function jump(location)
     if vim.g.ccls_close_on_jump then
         vim.api.nvim_buf_delete(nodeTree_bufno, { force = true })
     end
-    vim.lsp.util.jump_to_location(location, require("ccls.protocol").offset_encoding or "utf-32", true)
+    local encoding = require("ccls.protocol").offset_encoding or "utf-32"
+    -- jump_to_location is deprecated since Neovim 0.12; use show_document instead
+    if vim.lsp.util.show_document then
+        vim.lsp.util.show_document(location, encoding, { reuse_win = true, focus = true })
+    else
+        vim.lsp.util.jump_to_location(location, encoding, true)
+    end
 end
 
 --- Get the collapsibleState for a node. The root is returned expanded on


### PR DESCRIPTION
## Summary

- **Migrate deprecated API**: Replace `vim.lsp.util.jump_to_location` (deprecated in Neovim 0.12) with `vim.lsp.util.show_document`, with a fallback for older versions.

## Test plan

- [x] Open a C++ file, verify treesitter highlighting works
- [x] Use a cross-reference command (e.g. `CclsBaseHierarchy float`)
- [x] Press `<CR>` to jump to a result
- [x] Verify the target file opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)