### PR TITLE
feat: migrate to nvim 0.12 native LSP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A neovim plugin to configure ccls language server and use its extensions.
 [ccls](https://github.com/MaskRay/ccls) is a language server for `c`, `cpp` and variants that offers comparable
-on-spec features as `clangd` along with a many extensions.
+on-spec features as `clangd` along with many extensions.
 
 This plugin offers a tree-browser structure to parse the AST provided by [ccls
 extensions](https://github.com/MaskRay/ccls/wiki/LSP-Extensions) and to quickly navigate to them.
@@ -12,11 +12,14 @@ These AST features include:
 - member functions/variables of an object
 - base and derived hierarchy of a class
 - call hierarchy for a function
-- sturcts and variables of the same type in the project
+- structs and variables of the same type in the project
 
 There are some additional functionalities, follow the README for them.
 
 [ccls_demo.webm](https://user-images.githubusercontent.com/10258296/185764424-45945b84-f397-4fdf-87d4-abbdaed8a0fc.webm)
+
+> **Requires Neovim >= 0.12**
+> If you are on an older version, use the [`pre_refactor_to_0.12`](https://github.com/ranjithshegde/ccls.nvim/releases/tag/pre_refactor_to_0.12) tag.
 
 - [ccls extensions](#ccls-extensions)
   - [Quickfix](#quickfix)
@@ -28,34 +31,32 @@ There are some additional functionalities, follow the README for them.
     - [`$ccls/member` hierarchy](#cclsmember-hierarchy)
     - [`$ccls/call` hierarchy](#cclscall-hierarchy)
     - [`$ccls/inheritance` hierarchy](#cclsinheritance-hierarchy)
+  - [Navigate](#navigate)
 - [Configuration](#configuration)
   - [Window configuration](#window-configuration)
-  - [Filetypes](#filetypes)
   - [Lsp](#lsp)
-    - [Using lspcofing](#using-lspcofing)
-    - [Using direct call](#using-direct-call)
+    - [Default LSP config](#default-lsp-config)
+    - [Overriding LSP config](#overriding-lsp-config)
     - [Codelens](#codelens)
   - [Coexistence with clangd](#coexistence-with-clangd)
 - [NodeTree](#nodetree)
 - [TODO](#todo)
-  - [Preview](#preview)
-  - [Tests](#tests)
 
 **Features include**:
 
 - Most off-spec `ccls` features
-- Setup lsp either via `lspconfig` or built-in `vim.lsp.start()`
+- Native LSP setup via `vim.lsp.config` / `vim.lsp.enable` (nvim 0.12+)
 - Use treesitter to highlight NodeTree window
 - Update tagstack on jump to new node
 - Setup codelens autocmds
 
 ## ccls extensions
 
-`ccls` LSP has many off-spec commands/calls. This plugin supports the following
+`ccls` LSP has many off-spec commands/calls. This plugin supports the following.
 
 ### Quickfix
 
-The below functions return a quickfix list of items
+The below functions return a quickfix list of items.
 
 #### `$ccls/member`
 
@@ -64,25 +65,22 @@ kind 4 = variables, 3 = functions, 2 = type
 
 Individual member calls can also be made via
 
-- `:CclsMember` for Variables
+- `:CclsMember` for variables
 - `:CclsMemberFunction` for functions
 - `:CclsMemberType` for types
 
 #### `$ccls/call`
 
 Called via `require("ccls").call(callee)`.
-true = outgoing calls, false = incoming calls
-Can also be called via
+`true` = outgoing calls, `false` = incoming calls. Can also be called via:
 
 - `:CclsIncomingCalls`
 - `:CclsOutgoingCalls`
 
 #### `$ccls/inheritance`
 
-Called via `require("ccls").inheritance(derived)`
-derived `true` for derived classes, `false` for base classes
-
-Can also be called via
+Called via `require("ccls").inheritance(derived)`.
+`true` for derived classes, `false` for base classes. Can also be called via:
 
 - `:CclsBase`
 - `:CclsDerived`
@@ -90,79 +88,81 @@ Can also be called via
 #### `$ccls/vars`
 
 Called via `:CclsVars kind` or `require("ccls").vars(kind)`.
-This is similar to `textDocument/references` except it checks for the variable
-type.
-Kind values are 1 for all occurence of the variable type, 2 for defintion of
-current variable and 3 for references without definition.
+Similar to `textDocument/references` but filters by variable type.
+Kind values: 1 = all occurrences of the variable type, 2 = definition of current variable, 3 = references without definition.
 
 ### Sidebar or float
 
-The following functions are hierarchical and return either a sidebar or a
-floating window
+The following functions are hierarchical and return either a sidebar or a floating window.
 
-Each lua callback has a view option. View is a table with example `{type = "float"}` to use floating window.
-For vim commands it can be passed via `:CclsMemberHierarchy float`
-When omitted it uses a sidebar.
+Each Lua callback has a `view` option. Pass `{type = "float"}` for a floating window.
+For vim commands it can be passed via `:CclsMemberHierarchy float`.
+When omitted, a sidebar is used.
 
-Inside the window, use maps:
+Inside the window, use the following maps:
 
-- `o` to open a node under cursor.
-- `c` to close the node under cursor
-- `O` to toggle node under cursor
-- `CR` to jump to node under cursor
-- `q` To quit window
+- `o` — open node under cursor
+- `c` — close node under cursor
+- `O` — toggle node under cursor
+- `<CR>` — jump to node under cursor
+- `q` — quit window
 
 #### `$ccls/member` hierarchy
 
 Called via `require("ccls").memberHierarchy(kind, view)`.
-kind 4 = variables, 3 = functions, 2 = type
+kind 4 = variables, 3 = functions, 2 = type. Can also be called via:
 
-individual member calls can also be made via
-
-- `:CclsMemberHierarchy` for Variables
-- `:CclsMemberFunction` for functions
-- `:CclsMemberTyoe` for types
+- `:CclsMemberHierarchy` for variables
+- `:CclsMemberFunctionHierarchy` for functions
+- `:CclsMemberTypeHierarchy` for types
 
 #### `$ccls/call` hierarchy
 
-Called via `require("ccls").callHierarchy(callee)`.
-true = outgoing calls, false = incoming calls
-Can also be called via
+Called via `require("ccls").callHierarchy(callee, view)`.
+`true` = outgoing calls, `false` = incoming calls. Can also be called via:
 
 - `:CclsIncomingCallsHierarchy`
 - `:CclsOutgoingCallsHierarchy`
 
 #### `$ccls/inheritance` hierarchy
 
-Called via `require("ccls").inheritanceHierarchy(derived)`
-derived `true` for derived classes, `false` for base classes
-
-Can also be called via
+Called via `require("ccls").inheritanceHierarchy(derived, view)`.
+`true` for derived classes, `false` for base classes. Can also be called via:
 
 - `:CclsBaseHierarchy`
 - `:CclsDerivedHierarchy`
 
+### Navigate
+
+`$ccls/navigate` lets you jump between semantically related symbols in the AST — parent, child, or siblings — without opening a tree view.
+
+Called via `require("ccls").navigate(direction)` where direction is one of `"U"` (parent), `"D"` (first child), `"L"` (previous sibling), `"R"` (next sibling).
+
+Can also be called via:
+
+- `:CclsNavigateUp`
+- `:CclsNavigateDown`
+- `:CclsNavigateLeft`
+- `:CclsNavigateRight`
+
 ## Configuration
 
-Call `require("ccls").setup(config)` somewhere in your config
+Call `require("ccls").setup(config)` somewhere in your config.
 
 The default values are:
 
 <details>
-    <summary>Code</summary>
+<summary>Defaults</summary>
 
 ```lua
-defaults = {
+{
     win_config = {
-        -- Sidebar configuration
         sidebar = {
             size = 50,
-            position = "topleft",
-            split = "vnew",
+            position = "left",
             width = 50,
             height = 20,
         },
-        -- floating window configuration. check :help nvim_open_win for options
         float = {
             style = "minimal",
             relative = "cursor",
@@ -173,16 +173,12 @@ defaults = {
             border = "rounded",
         },
     },
-    filetypes = {"c", "cpp", "objc", "objcpp"},
-
-    -- Lsp is not setup by default to avoid overriding user's personal configurations.
-    -- Look ahead for instructions on using this plugin for ccls setup
     lsp = {
         codelens = {
-            enabled = false,
-            events = {"BufEnter", "BufWritePost"}
-        }
-    }
+            enable = false,
+            events = { "BufEnter", "BufWritePost" },
+        },
+    },
 }
 ```
 
@@ -192,247 +188,144 @@ Any of the configuration options can be omitted.
 
 ### Window configuration
 
-`win_config` table accepts two keys:
+`win_config` accepts two keys:
 
--`sidebar`: split options
-
--`float`: same options supplied to `nvim_open_win` or other default floating
-windows
-
-### Filetypes
-
-By default, this plugin works on all filetypes accepted by `ccls` language
-server. You can customize this by adding `filetypes` table to the config
-
-```lua
-require("ccls").setup({filetypes = {"c", "cpp", "opencl"}})
-```
+- `sidebar`: controls the split window. `position` maps to the `split` field of `nvim_open_win` (e.g. `"left"`, `"right"`). `size` sets the width.
+- `float`: options passed directly to `nvim_open_win`.
 
 ### Lsp
 
-You can optionally setup LSP through the plugin. _By default no setup calls are
-initiated_.
+> **Note:** LSP setup requires Neovim >= 0.12. If you are not on 0.12, use the `pre_refactor_to_0.12` tag and refer to its README.
 
-There are two methods.
+This plugin uses Neovim's native `vim.lsp.config` / `vim.lsp.enable` API. **No lspconfig dependency is required.**
 
-#### Using lspcofing
+#### Default LSP config
 
-This requires that you have [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin installed (and already
-loaded if lazy-loading). Pass the appropriate configurations like this.
+A default LSP config is provided in `lsp/ccls.lua` and is automatically picked up by Neovim's LSP config discovery (`:h lsp-config`). It sets:
 
-<details>
-    <summary>Code</summary>
+- `cmd = { "ccls" }`
+- `filetypes = { "c", "cpp", "objc", "objcpp", "cuda" }`
+- `offset_encoding = "utf-32"`
+- `workspace_required = true`
+- `root_markers = { "compile_commands.json", "compile_flags.txt", ".ccls", ".git" }`
+
+If this is sufficient for your setup, you do not need to pass a `server` table at all. Just call:
 
 ```lua
-    local util = require "lspconfig.util"
-    local server_config = {
-        filetypes = { "c", "cpp", "objc", "objcpp", "opencl" },
-        root_dir = function(fname)
-            return util.root_pattern("compile_commands.json", "compile_flags.txt", ".git")(fname)
-                or util.find_git_ancestor(fname)
-        end,
-        init_options = { cache = {
-            directory = vim.env.XDG_CACHE_HOME .. "/ccls/",
-            -- or vim.fs.normalize "~/.cache/ccls" -- if on nvim 0.8 or higher
-        } },
-        --on_attach = require("my.attach").func,
-        --capabilities = my_caps_table_or_func
-    }
-    require("ccls").setup { lsp = { lspconfig = server_config } }
+require("ccls").setup({ lsp = {--[[other config, not server table]] })
 ```
 
-</details>
+#### Overriding LSP config
 
-Any option omitted will use `lspconfig` defaults.
-
-It is also possible to entirely use lspconfig defaults like this:
+To override any of the defaults, pass a `server` table inside `lsp`:
 
 ```lua
-require("ccls").setup({lsp = {use_defaults = true}})
-```
-
-#### Using direct call
-
-If using _nvim 0.8_, you can use `vim.lsp.start()` call instead which has the
-benefit of reusing the same client on files within the same workspace.
-
-To use that, pass this in your config, without supplying the keys `use_defaults`
-or `lspconfig`.
-
-**Warning:** Requires `nvim 0.8`
-
-<details>
-    <summary>Code</summary>
-
-```lua
-require("ccls").setup {
+require("ccls").setup({
     lsp = {
-        -- check :help vim.lsp.start for config options
         server = {
-            name = "ccls", --String name
-            cmd = {"/usr/bin/ccls"}, -- point to your binary, has to be a table
-            args = {--[[Any args table]] },
-            offset_encoding = "utf-32", -- default value set by plugin
-            root_dir = vim.fs.dirname(vim.fs.find({ "compile_commands.json", ".git" }, { upward = true })[1]), -- or some other function that returns a string
-            --on_attach = your_func,
-            --capabilites = your_table/func
+            cmd = { "/usr/local/bin/ccls" },
+            root_markers = { "compile_commands.json", ".git" },
+            -- any other vim.lsp.config-compatible keys
         },
     },
-}
-```
-
-</details>
-
-If neither `use_defaults`, `lspconfig` nor `server` are set,
-then the plugin assumes you have setup ccls LSP elsewhere in your config.
-This is the default behaviour.
-
-#### Codelens
-
-ccls has minimal codelens capabilites. If you are not familiar with codenels, see [Lsp spec
-documentation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens).
-According to ccls server capabilities tree, ccls supports `resolveProvider`
-option of codelens.
-
-To enable codelens, set `lsp = { codelens = {enable = true}}` in the config.
-It is necessary to setup autocmds to refresh codelens. The default events are
-`BufEnter` and `BufWritePost`. You can customize it this way:
-
-```lua
-require('ccls').setup({
-    lsp = {
-        codelens = {
-            enable = true,
-            events = {"BufWritePost", "InsertLeave"}
-        }
-    }
 })
 ```
 
-_Note:_ Setting up codelens using this plugin requires neovim >= 0.8 as
-`LspAttach` autocmd is only avaialble from version 0.8
+The `server` table is merged on top of the base config via `vim.lsp.config`.
+
+> **Removed options:** `use_defaults`, `lspconfig`, and `root_dir` (string) are no longer supported. Use `root_markers` (table) instead, which is handled natively by Neovim's LSP client. The `lspconfig` dependency has been fully dropped.
+
+#### Codelens
+
+ccls has minimal codelens capabilities. See the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens) for background.
+
+To enable codelens:
+
+```lua
+require("ccls").setup({
+    lsp = {
+        codelens = {
+            enable = true,
+            events = { "BufWritePost", "InsertLeave" }, -- optional, these are not the defaults
+        },
+    },
+})
+```
+
+Default refresh events are `BufEnter` and `BufWritePost`.
 
 ### Coexistence with clangd
 
-If you wish to use clangd alongside ccls and want to avoid conflicting parallel
-requests, you can use the following table to disable specific capabilities.
+If you use clangd alongside ccls and want to avoid conflicting parallel requests, you can disable specific capabilities and handlers.
 
-_Warning:_ Upstream (neovim) maintainers label the process of disabling
-capabilities as _hacky_. Until there is a mechanism in-place upstream that
-uses predicates to select clients for calls, this is the best solution.
-
-This method uses both disabling certain capabilities and passing `nil` handlers
-to others. This makes running two language servers more resource efficient.
-
-Use only the following options. If you do not wish to disable said option,
-either set it to false or simply leave out that option.
+> **Note:** Upstream Neovim maintainers consider disabling capabilities a workaround. This remains the best available approach until a predicate-based client selection mechanism lands upstream.
 
 <details>
-    <summary>Code</summary>
+<summary>Full example (from my local config)</summary>
 
 ```lua
-require("ccls").setup {
-    lsp = {
-        disable_capabilities = {
-            completionProvider = true,
-            documentFormattingProvider = true,
-            documentRangeFormattingProvider = true,
-            documentHighlightProvider = true,
-            documentSymbolProvider = true,
-            workspaceSymbolProvider = true,
-            renameProvider = true,
-            hoverProvider = true,
-            codeActionProvider = true,
-        },
-        disable_diagnostics = true,
-        disable_signature = true,
-    },
-}
-```
+    local cpu_count = #vim.uv.cpu_info()
+    local ccls_threads = math.max(1, cpu_count - 1)
 
-</details>
-
-**Note:** For these disabling mechanisms to be attached to the initiated/running ccls
-instance, you will have to configure the server through the plugin either using
-`lsp = {lspconfig = {my_config_table}}` or `lsp={server={my_0.8.config}}` as
-descried earlier.
-
-<details>
-    <summary>Here is a complete setup example from my config (using nvim 0.8 features) </summary>
-
-```lua
-    local filetypes = { "c", "cpp", "objc", "objcpp", "opencl" }
     local server_config = {
-        filetypes = filetypes,
-        init_options = { cache = {
-            directory = vim.fs.normalize "~/.cache/ccls/",
-        } },
-        name = "ccls",
-        cmd = { "ccls" },
-        offset_encoding = "utf-32",
-        root_dir = vim.fs.dirname(
-            vim.fs.find({ "compile_commands.json", "compile_flags.txt", ".git" }, { upward = true })[1]
-        ),
+        cmd = { 'ccls', '--log-file=/tmp/ccls.log', '--v=0' },
+        filetypes = { 'c', 'cpp', 'objc', 'objcpp', 'opencl' },
+        init_options = {
+            threads = ccls_threads,
+            index = {
+                trackDependency = 1,
+                blacklist = { '^build/', '^.cache/', '^bin/', '^packaging', '^res' },
+            },
+            cache = {
+                directory = '.ccls-cache',
+            },
+        },
     }
-    require("ccls").setup {
-        filetypes = filetypes,
+
+    require('ccls').setup {
         lsp = {
             server = server_config,
             disable_capabilities = {
                 completionProvider = true,
                 documentFormattingProvider = true,
+                definitionProvider = true,
                 documentRangeFormattingProvider = true,
                 documentHighlightProvider = true,
                 documentSymbolProvider = true,
-                workspaceSymbolProvider = true,
-                renameProvider = true,
                 hoverProvider = true,
-                codeActionProvider = true,
+                referencesProvider = true,
+                renameProvider = true,
+                typeDefinitionProvider = true,
+                workspaceSymbolProvider = true,
             },
             disable_diagnostics = true,
             disable_signature = true,
-            codelens = { enable = true }
-        },
+            codelens = { enable = true } },
     }
 ```
 
 </details>
 
-<details>
-    <summary>Notes</summary>
-
 ## NodeTree
 
-As of now, the `NodeTree` filetype which renders a tree structure is a direct
-lua rewrite of Martin Pilia's `vim-yggdrasil`. At some point in the future I
-will rewrite the logic to utilize more lua-ecosystem features and make it
-a general purpose Tree browser.
+The `NodeTree` filetype renders the tree structure returned by ccls hierarchy queries. It is a Lua rewrite of Martin Pilia's `vim-yggdrasil`. The code structure is:
 
-For now, it works exactly as intended but is not easy read. The code structure is as follows.
-
-- `ccls/provider.lua` contains functions to make LSP results compatible with
-  NodeTree.
-- `ccls/tree` Folder has the luafied `yggdrasil` tree code
-  - `ccls/tree/tree.lua` has the Tree class.
-  - `ccls/tree/node.lua` has the node class reduced to a single node generator call
-    to avoid caching problems. Will be modularized when I rewrite the logic.
-  - `ccls/tree/utils.lua` has other function calls not part of `tree` or `node` class but necessary
+- `ccls/provider.lua` — adapts LSP results into a NodeTree-compatible format
+- `ccls/tree/tree.lua` — Tree class
+- `ccls/tree/node.lua` — node constructor and rendering logic
 
 ## TODO
 
 ### Preview
 
-Open a floating preview window for node under the cursor from Sidebar
+Open a floating preview window for the node under cursor from the sidebar.
 
 ### Tests
 
-This will take some time. Need to figure out how to run a language server for testing.
-I will look through other plugins to see how they handle it. No promise on time.
-
-</details>
+Need to figure out how to run a language server in a test environment. Will look through other plugins for prior art.
 
 ## Credits
 
-- [MaskRay](https://github.com/MaskRay) Thank you for creating the LSP!
-- [vim-ccls](https://github.com/m-pilia/vim-ccls) for inspiration and speicifc ideas on translating LSP data into tree-like structure.
-- [vim-yggdrasil](https://github.com/m-pilia/vim-yggdrasil) The entire tree-browser part of the code is a lua rewrite of this plugin.
+- [MaskRay](https://github.com/MaskRay) — thank you for creating the LSP!
+- [vim-ccls](https://github.com/m-pilia/vim-ccls) — inspiration and ideas for translating LSP data into tree structure.
+- [vim-yggdrasil](https://github.com/m-pilia/vim-yggdrasil) — the entire tree-browser part of the code is a Lua rewrite of this plugin.

--- a/lsp/ccls.lua
+++ b/lsp/ccls.lua
@@ -1,0 +1,6 @@
+return {
+    cmd = { "ccls" },
+    filetypes = { "c", "cpp", "objc", "objcpp" },
+    offset_encoding = "utf-32",
+    root_markers = { "compile_commands.json", "compile_flags.txt", ".ccls", ".git" },
+}

--- a/lsp/ccls.lua
+++ b/lsp/ccls.lua
@@ -1,6 +1,7 @@
 return {
     cmd = { "ccls" },
-    filetypes = { "c", "cpp", "objc", "objcpp" },
+    filetypes = { "c", "cpp", "objc", "objcpp", "cuda" },
     offset_encoding = "utf-32",
+    workspace_required = true,
     root_markers = { "compile_commands.json", "compile_flags.txt", ".ccls", ".git" },
 }

--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -134,4 +134,8 @@ function ccls.inheritanceHierarchy(derived, view)
     require("ccls.protocol").request("$ccls/inheritance", { derived = derived or false }, true, view)
 end
 
+function ccls.navigate(direction)
+    require("ccls.protocol").navigate(direction)
+end
+
 return ccls

--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -2,8 +2,7 @@ local ccls = {
     win_config = {
         sidebar = {
             size = 50,
-            position = "topleft",
-            split = "vnew",
+            position = "left",
             width = 50,
             height = 20,
         },

--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -67,11 +67,6 @@ function ccls.setup(config)
             end
         end
 
-        if utils.tbl_haskey(config.lsp, false, "use_defaults") and config.lsp.use_defaults == true then
-            require("ccls.protocol").setup_lsp "lspconfig"
-            return
-        end
-
         if config.lsp.disable_diagnostics then
             table.insert(nil_handlers, "textDocument/publishDiagnostics")
         end
@@ -87,39 +82,26 @@ function ccls.setup(config)
             ccls.lsp.disable_capabilities = config.lsp.disable_capabilities
         end
 
-        if utils.tbl_haskey(config.lsp, false, "lspconfig") then
-            vim.validate { lspconfig = { config.lsp.lspconfig, "table" } }
-            require("ccls.protocol").setup_lsp("lspconfig", config.lsp.lspconfig)
+        if vim.fn.has "nvim-0.12" ~= 1 then
+            vim.notify(
+                [[Attempting to configure Lsp server. This feature requires nvim>= 0.12]],
+                vim.log.levels.ERROR,
+                { title = "ccls.nvim" }
+            )
             return
         end
 
         if utils.tbl_haskey(config.lsp, false, "server") then
-            if vim.fn.has "nvim-0.8" ~= 1 then
-                vim.notify(
-                    [[Attempting to set key `config.lsp.server`. This feature requires nvim>= 0.8. Either upadte to nvim-nightly or use config.lsp.lspconfig]],
-                    vim.log.levels.ERROR,
-                    { title = "ccls.nvim" }
-                )
-                return
-            end
             vim.validate {
                 name = { config.lsp.server.name, "string", true },
                 cmd = { config.lsp.server.cmd, "table", true },
                 args = { config.lsp.server.args, "table", true },
                 offset_encoding = { config.lsp.server.offset_encoding, "string", true },
-                root_dir = { config.lsp.server.root_dir, "string", true },
+                root_markers = { config.lsp.server.root_markers, "table", true },
             }
-            require("ccls.protocol").setup_lsp("server", config.lsp.server)
-            return
         end
 
-        vim.notify(
-            [[Lsp config: Neither `use_defaults` nor server configurations have been specified.
-            This will assume that Lsp configuration for ccls has been handled by the user elsewhere
-        ]],
-            vim.log.levels.INFO,
-            { title = "ccls.nvim" }
-        )
+        require("ccls.protocol").setup_lsp(config.lsp.server)
     end
 end
 

--- a/lua/ccls/init.lua
+++ b/lua/ccls/init.lua
@@ -99,6 +99,8 @@ function ccls.setup(config)
                 offset_encoding = { config.lsp.server.offset_encoding, "string", true },
                 root_markers = { config.lsp.server.root_markers, "table", true },
             }
+        else
+            config.lsp.server = {}
         end
 
         require("ccls.protocol").setup_lsp(config.lsp.server)

--- a/lua/ccls/protocol.lua
+++ b/lua/ccls/protocol.lua
@@ -176,6 +176,37 @@ function protocol.request(method, config, hierarchy, view)
     end
 end
 
+function protocol.navigate(direction)
+    local bufnr = vim.api.nvim_get_current_buf()
+    local cursor = vim.fn.getcurpos()
+    local params = {
+        textDocument = { uri = vim.uri_from_bufnr(bufnr) },
+        position = {
+            line = cursor[2] - 1,
+            character = cursor[3] - 1,
+        },
+        direction = direction,
+    }
+
+    local client = vim.lsp.get_clients({ name = "ccls", bufnr = bufnr })[1]
+    if not client then
+        vim.notify("Ccls is not attached to this buffer", vim.log.levels.WARN, { title = "ccls.nvim" })
+        return
+    end
+
+    client:request("$ccls/navigate", params, function(err, result)
+        if err or not result then
+            vim.notify("No navigate result", vim.log.levels.WARN, { title = "ccls.nvim" })
+            return
+        end
+        local location = vim.islist(result) and result[1] or result
+        if not location then
+            return
+        end
+        vim.lsp.util.show_document(location, client.offset_encoding, { reuse_win = true, focus = true })
+    end, bufnr)
+end
+
 function protocol.setup_lsp(config)
     local utils = require "ccls.tree.utils"
     local lsp_config = require("ccls").lsp

--- a/lua/ccls/protocol.lua
+++ b/lua/ccls/protocol.lua
@@ -186,10 +186,6 @@ function protocol.setup_lsp(config)
         enable_codelens(lsp_config.codelens.events)
     end
 
-    if not utils.assert_table(config) then
-        config = {}
-    end
-
     if utils.assert_table(lsp_config.disable_capabilities) then
         config.on_init = disable_capabilities(lsp_config.disable_capabilities)
     end
@@ -198,14 +194,7 @@ function protocol.setup_lsp(config)
         set_nil_handlers(config, lsp_config.nil_handlers)
     end
 
-    vim.api.nvim_create_autocmd("FileType", {
-        pattern = config.filetypes or { "c", "cpp", "objc", "objcpp" },
-        group = vim.api.nvim_create_augroup("ccls_config", { clear = true }),
-        callback = function()
-            vim.lsp.config("ccls", config)
-        end,
-    })
-
+    vim.lsp.config("ccls", config)
     vim.lsp.enable("ccls", true)
 end
 

--- a/lua/ccls/protocol.lua
+++ b/lua/ccls/protocol.lua
@@ -1,13 +1,5 @@
 local protocol = {}
 
-local default_config = {
-    name = "ccls",
-    cmd = { "ccls" },
-    filetypes = { "c", "cpp", "objc", "objcpp" },
-    offset_encoding = "utf-32",
-    single_file_support = false,
-}
-
 local config_aug = vim.api.nvim_create_augroup("ccls_lsp_setup", { clear = true })
 
 local function disable_capabilities(rules)
@@ -43,18 +35,6 @@ local function set_nil_handlers(config, handles)
     end
 end
 
-local function set_root_dir(type)
-    if type ~= "lspconfig" then
-        default_config.root_dir =
-            vim.fs.dirname(vim.fs.find({ "compile_commands.json", "compile_flags.txt", ".git" }, { upward = true })[1])
-    else
-        default_config.root_dir = function(fname)
-            return require("lspconfig.util").root_pattern("compile_commands.json", "compile_flags.txt", ".git")(fname)
-                or require("lspconfig.util").find_git_ancestor(fname)
-        end
-    end
-end
-
 local function enable_codelens(events)
     local codelens_aug = vim.api.nvim_create_augroup("ccls_codelens", { clear = true })
 
@@ -66,10 +46,12 @@ local function enable_codelens(events)
                 vim.api.nvim_create_autocmd(events, {
                     group = codelens_aug,
                     buffer = args.buf,
-                    callback = vim.lsp.codelens.refresh,
+                    callback = function()
+                        vim.lsp.codelens.enable(true)
+                    end,
                     desc = "Refresh ccls codelens",
                 })
-                vim.lsp.codelens.refresh()
+                vim.lsp.codelens.enable(true)
             end
         end,
         desc = "Create codelens autocmd on Lsp Attach",
@@ -88,9 +70,8 @@ local function enable_codelens(events)
 end
 
 local function qfRequest(params, method, bufnr, name)
-    local util = require "lspconfig.util"
-    bufnr = util.validate_bufnr(bufnr)
-    local client = util.get_active_client_by_name(bufnr, "ccls")
+    bufnr = bufnr == 0 and vim.api.nvim_get_current_buf() or bufnr
+    local client = vim.lsp.get_clients({ name = "ccls", bufnr = bufnr })[1]
 
     if client then
         local function handler(_, result, ctx, _)
@@ -151,9 +132,8 @@ local function handle_tree(bufnr, method, extra_params, view, data)
 end
 
 function protocol.nodeRequest(bufnr, method, params, handler)
-    local util = require "lspconfig.util"
-    bufnr = util.validate_bufnr(bufnr)
-    local client = util.get_active_client_by_name(bufnr, "ccls")
+    bufnr = bufnr == 0 and vim.api.nvim_get_current_buf() or bufnr
+    local client = vim.lsp.get_clients({ name = "ccls", bufnr = bufnr })[1]
 
     local lspHandler = function(err, result, _, _)
         if err or not result then
@@ -198,47 +178,35 @@ function protocol.request(method, config, hierarchy, view)
     end
 end
 
-function protocol.setup_lsp(type, config)
+function protocol.setup_lsp(config)
     local utils = require "ccls.tree.utils"
     local lsp_config = require("ccls").lsp
-
-    if not config or not config.root_dir then
-        set_root_dir(type)
-    end
 
     if lsp_config.codelens.enable then
         enable_codelens(lsp_config.codelens.events)
     end
 
-    if utils.assert_table(config) then
-        default_config = vim.tbl_extend("force", default_config, config)
-    else
-        require("lspconfig").ccls.setup(default_config)
-        return
+    if not utils.assert_table(config) then
+        config = {}
     end
 
     if utils.assert_table(lsp_config.disable_capabilities) then
-        default_config.on_init = disable_capabilities(lsp_config.disable_capabilities)
+        config.on_init = disable_capabilities(lsp_config.disable_capabilities)
     end
 
     if utils.assert_table(lsp_config.nil_handlers) then
-        set_nil_handlers(default_config, lsp_config.nil_handlers)
+        set_nil_handlers(config, lsp_config.nil_handlers)
     end
 
-    if type == "lspconfig" then
-        require("lspconfig").ccls.setup(default_config)
-        return
-    end
+    vim.api.nvim_create_autocmd("FileType", {
+        pattern = config.filetypes or { "c", "cpp", "objc", "objcpp" },
+        group = vim.api.nvim_create_augroup("ccls_config", { clear = true }),
+        callback = function()
+            vim.lsp.config("ccls", config)
+        end,
+    })
 
-    if type == "server" then
-        vim.api.nvim_create_autocmd("FileType", {
-            pattern = default_config.filetypes or { "c", "cpp", "objc", "objcpp" },
-            group = vim.api.nvim_create_augroup("ccls_config", { clear = true }),
-            callback = function()
-                vim.lsp.start(default_config)
-            end,
-        })
-    end
+    vim.lsp.enable("ccls", true)
 end
 
 return protocol

--- a/lua/ccls/protocol.lua
+++ b/lua/ccls/protocol.lua
@@ -87,7 +87,7 @@ local function qfRequest(params, method, bufnr, name)
             end
         end
 
-        client.request(method, params, handler, bufnr)
+        client:request(method, params, handler, bufnr)
     else
         vim.notify("Ccls is not attached to this buffer", vim.log.levels.WARN, { title = "ccls.nvim" })
     end
@@ -97,6 +97,7 @@ end
 local function handle_tree(bufnr, method, extra_params, view, data)
     if type(data) ~= "table" then
         vim.notify("No hierarchy for the object under the cursor", nil, { title = "ccls.nvim" })
+        return
     end
 
     local win_config = require("ccls").win_config
@@ -104,28 +105,25 @@ local function handle_tree(bufnr, method, extra_params, view, data)
     local p = require("ccls.provider"):create(data, method, bufnr, extra_params)
     local float_buf
 
-    if view and view.type and view.type == "float" then
-        local float_id = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), true, win_config.float)
-        float_buf = vim.api.nvim_win_get_buf(float_id)
-        vim.fn.win_gotoid(float_id)
+    local is_float = view and view.type and view.type == "float"
+    local cfg = is_float and win_config.float
+        or {
+            split = win_config.sidebar.position,
+            width = win_config.sidebar.size,
+        }
 
+    local win_id = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), true, cfg)
+    float_buf = vim.api.nvim_win_get_buf(win_id)
+
+    if is_float then
         vim.api.nvim_create_autocmd("WinLeave", {
             buffer = float_buf,
             group = au,
             callback = function()
-                vim.api.nvim_win_close(float_id, true)
+                vim.api.nvim_win_close(win_id, true)
             end,
             once = true,
         })
-    else
-        vim.api.nvim_exec(
-            win_config.sidebar.position .. " " .. win_config.sidebar.size .. win_config.sidebar.split,
-            false
-        )
-        local new_buf = vim.api.nvim_get_current_buf()
-        if new_buf ~= bufnr then
-            float_buf = new_buf
-        end
     end
 
     require("ccls.tree").init(p, float_buf)

--- a/lua/ccls/provider.lua
+++ b/lua/ccls/provider.lua
@@ -35,12 +35,8 @@ local function jump(location)
         vim.api.nvim_buf_delete(nodeTree_bufno, { force = true })
     end
     local encoding = require("ccls.protocol").offset_encoding or "utf-32"
-    -- jump_to_location is deprecated since Neovim 0.12; use show_document instead
-    if vim.lsp.util.show_document then
-        vim.lsp.util.show_document(location, encoding, { reuse_win = true, focus = true })
-    else
-        vim.lsp.util.jump_to_location(location, encoding, true)
-    end
+
+    vim.lsp.util.show_document(location, encoding, { reuse_win = true, focus = true })
 end
 
 --- Get the collapsibleState for a node. The root is returned expanded on

--- a/lua/ccls/tree/tree.lua
+++ b/lua/ccls/tree/tree.lua
@@ -54,7 +54,7 @@ end
 --- tree view. Clear the index, setting it to a list containing a guard
 --- value for index 0 (line numbers are one-based).
 function Tree:render()
-    if vim.api.nvim_buf_get_option(0, "filetype") ~= "NodeTree" then
+    if vim.bo.filetype ~= "NodeTree" then
         return
     end
 

--- a/plugin/ccls.lua
+++ b/plugin/ccls.lua
@@ -59,3 +59,19 @@ end, { nargs = "*", desc = "ccls member functions" })
 cmd("CclsMemberTypeHierarchy", function(opts)
     require("ccls").memberHierarchy(2, { type = opts.args })
 end, { nargs = "*", desc = "ccls member types" })
+
+cmd("CclsNavigateUp", function()
+    require("ccls").navigate "U"
+end, { desc = "ccls navigate to parent" })
+
+cmd("CclsNavigateDown", function()
+    require("ccls").navigate "D"
+end, { desc = "ccls navigate to first child" })
+
+cmd("CclsNavigateLeft", function()
+    require("ccls").navigate "L"
+end, { desc = "ccls navigate to previous sibling" })
+
+cmd("CclsNavigateRight", function()
+    require("ccls").navigate "R"
+end, { desc = "ccls navigate to next sibling" })


### PR DESCRIPTION
## Summary

Migrates the plugin to use Neovim's native vim.lsp.config / vim.lsp.enable
API, dropping the lspconfig dependency entirely. Adds $ccls/navigate support.

## Breaking Changes

- Requires Neovim >= 0.12. Use the [pre_refactor_to_0.12](https://github.com/ranjithshegde/ccls.nvim/releases/tag/pre_refactor_to_0.12) for older versions.
- `lsp.use_defaults` and `lsp.lspconfig` config keys are removed.
- `lsp.server.root_dir` (string) is replaced by `root_markers` (table).
- The lspconfig dependency is fully dropped.

## Changes

- Add lsp/ccls.lua for native LSP config discovery
- Replace lspconfig utilities with vim.lsp.get_clients and client:request
- Remove default_config, set_root_dir, and lspconfig/server branching in protocol.lua
- Add $ccls/navigate with CclsNavigateUp/Down/Left/Right commands
- Fix missing return in handle_tree after error notify
- Fix client.request → client:request in qfRequest
- Use vim.bo.filetype instead of deprecated nvim_buf_get_option
- Use vim.lsp.codelens.enable instead of codelens.refresh
- Add cuda to default filetypes, workspace_required = true in lsp/ccls.lua
- Update README for all of the above

## Linkage
- Closes: #14 
- Closes #16 